### PR TITLE
Clean up notification code

### DIFF
--- a/Hourglass/Hourglass/Managers/UserNotificationManager.swift
+++ b/Hourglass/Hourglass/Managers/UserNotificationManager.swift
@@ -18,7 +18,7 @@ class UserNotificationManager: NSObject, NotificationManager {
     private func requestAuthorizationIfNeeded() {
         userNotificationCenter.getNotificationSettings { settings in
             if settings.authorizationStatus == .notDetermined {
-                self.userNotificationCenter.requestAuthorization(options: [.sound])
+                self.userNotificationCenter.requestAuthorization(options: [.sound, .alert])
                 { granted, error in }
             }
         }
@@ -29,7 +29,7 @@ class UserNotificationManager: NSObject, NotificationManager {
         let notificationContent = notification.contentBase
             .sound(soundIsEnabled ? .default : nil)
 
-        let request = UNNotificationRequest(identifier: "",
+        let request = UNNotificationRequest(identifier: notification.id,
                                             content: notificationContent,
                                             trigger: nil)
 

--- a/Hourglass/Hourglass/Utilities/Constants.swift
+++ b/Hourglass/Hourglass/Utilities/Constants.swift
@@ -21,9 +21,6 @@ enum Constants {
     // Timer alert dialog
     static let timerCompleteAlert = "Time's up"
 
-    // Window Ids
-    static let aboutWindowId = UUID().uuidString
-
     // Timestamp default
     static let timeStampZero = "00:00"
 

--- a/Hourglass/Hourglass/Utilities/Notifications.swift
+++ b/Hourglass/Hourglass/Utilities/Notifications.swift
@@ -2,7 +2,7 @@ import UserNotifications
 
 enum HourglassNotification: String {
     case timerCompleteBanner
-    case noBanner
+    case timerCompleteNoBanner
 
     var contentBase: UNMutableNotificationContent {
         let notificationContent = UNMutableNotificationContent()
@@ -15,8 +15,12 @@ enum HourglassNotification: String {
         switch self {
         case .timerCompleteBanner:
             return Constants.timerCompleteAlert
-        case .noBanner:
+        case .timerCompleteNoBanner:
             return ""
         }
+    }
+
+    var id: String {
+        rawValue
     }
 }

--- a/Hourglass/Hourglass/ViewModel.swift
+++ b/Hourglass/Hourglass/ViewModel.swift
@@ -119,7 +119,7 @@ class ViewModel: ObservableObject {
                                                          soundIsEnabled: soundIsEnabled)
             case .popup:
                 if soundIsEnabled {
-                    userNotificationManager.fireNotification(.noBanner,
+                    userNotificationManager.fireNotification(.timerCompleteNoBanner,
                                                              soundIsEnabled: true)
                 }
                 viewState.showTimerCompleteAlert = true

--- a/Hourglass/HourglassUITests/HourglassUITests.swift
+++ b/Hourglass/HourglassUITests/HourglassUITests.swift
@@ -65,7 +65,15 @@ final class HourglassUITests: XCTestCase {
         okButton.tap()
     }
 
-    // Note: - Locally, notifications must be visible (DND off).
+    /**
+     Test local notification via UNUserNotificationCenter on timer complete.
+
+     For this test to work:
+     - Locally, notifications must be visible (DND off)
+     - System settings notifications enabled for app,  style is alert (not banner)
+        - For some reason, when banner is elected, the notification appears quietly in Notification Center during testing
+     - Menu bar is not hidden (Desktop and Dock system settings)
+     */
     func testStartTimerToCompletionBanner() {
         app.setTimerLength(2, for: .timerRestSmall)
         app.setNotificationStyle(.banner)


### PR DESCRIPTION
- Add back `.alert` option to authorization request
- Rename `noBanner` notification to `timerCompleteNoBanner`
- Use HourglassNotification case names as notification ids
- Delete `aboutWindowId` constant (was used in MenuBarExtra)
- Document how to get notification banner UI test working locally
- Closes #40