### PR TITLE
Remove push trigger from CI script

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -6,7 +6,6 @@ workflows:
       xcode: 14.2
     triggering:
       events:
-        - push
         - pull_request
         - tag
       cancel_previous_builds: true


### PR DESCRIPTION
- Only trigger CI on PRs and tags to reduce noise from pushing