### PR TITLE
Wire up TMSM delegate to reset app state

### DIFF
--- a/Hourglass/Hourglass/Managers/SettingsManager.swift
+++ b/Hourglass/Hourglass/Managers/SettingsManager.swift
@@ -90,6 +90,16 @@ extension UserDefaults {
             as? Int ?? Constants.enforceRestThreshold
         }
     }
+
+    @objc dynamic var getBackToWork: Bool {
+        set {
+            set(newValue, forKey: SettingsKeys.getBackToWork.rawValue)
+        }
+        get {
+            object(forKey: SettingsKeys.getBackToWork.rawValue)
+            as? Bool ?? Constants.getBackToWorkIsEnabled
+        }
+    }
 }
 
 struct SettingsManager {
@@ -165,12 +175,11 @@ struct SettingsManager {
 
     // Get Back to Work
     func setGetBackToWork(isEnabled: Bool) {
-        store.set(isEnabled, forKey: SettingsKeys.getBackToWork.rawValue)
+        store.getBackToWork = isEnabled
     }
 
     func getGetBackToWorkIsEnabled() -> Bool {
-        store.object(forKey: SettingsKeys.getBackToWork.rawValue)
-        as? Bool ?? Constants.getBackToWorkIsEnabled
+        store.getBackToWork
     }
 
     // Sound


### PR DESCRIPTION
- Move timer length state change to TMSM
- Create TimerHandling protocol to reset timer states via TMSM
- Expose GBTW setting to objc for KVO
- Logic to reset focus stride, reset active timer (if any), and set all timers to default state - in that order - on change of any rest settings
- Closes #72 