### PR TITLE
Handle GBTW setting toggle

### DIFF
--- a/Hourglass/Hourglass/Managers/TimerModelStateManager.swift
+++ b/Hourglass/Hourglass/Managers/TimerModelStateManager.swift
@@ -176,8 +176,12 @@ class TimerModelStateManager {
             self.didChangeRestSettings()
         }
 
-        settingsManager.observe(\.getBackToWork) { _ in
-            self.didChangeRestSettings()
+        settingsManager.observe(\.getBackToWork) { [self] isEnabled in
+            if !isEnabled {
+                if timerModels.filterByCategory(.rest).allSatisfy({$0.state == .disabled}) {
+                    setTimers(category: .rest, state: .inactive)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- Instead of resetting the app state, re-enable rest timers (if disabled) when toggling the setting off
- Otherwise, no app state change (the setting is only activated - modifying state - when user completes a rest timer)