### PR TITLE
Fix timer grid column width + fix header size

### DIFF
--- a/Hourglass/Hourglass/Views/TimerButton.swift
+++ b/Hourglass/Hourglass/Views/TimerButton.swift
@@ -18,8 +18,9 @@ struct TimerButton: View {
 }
 
 extension TimerButton {
+    static let size: Double = 56
+
     private struct Style: ButtonStyle {
-        let size: Double = 56
         let state: Timer.State
 
         init(for state: Timer.State) {

--- a/Hourglass/Hourglass/Views/TimerGrid.swift
+++ b/Hourglass/Hourglass/Views/TimerGrid.swift
@@ -16,6 +16,7 @@ struct TimerGrid: View {
                     }
                 }
             }
+            .frame(width: TimerButton.size)
 
             VStack(alignment: .center, spacing: ySpacing) {
                 Header(content: Copy.restHeader)
@@ -26,6 +27,7 @@ struct TimerGrid: View {
                     }
                 }
             }
+            .frame(width: TimerButton.size)
         }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("timer-grid")
@@ -44,6 +46,7 @@ private struct Header: View {
 
     var body: some View {
         Text(content)
+            .fixedSize()
             .foregroundColor(Color.Hourglass.onBackgroundPrimary)
     }
 }


### PR DESCRIPTION
- This allows the "focus" header length to not impact the width of the column