### PR TITLE
Fix annotation placement bug

### DIFF
--- a/Hourglass/Hourglass/Views/StatisticsView.swift
+++ b/Hourglass/Hourglass/Views/StatisticsView.swift
@@ -217,8 +217,9 @@ struct StatisticsView: View {
             alignment = .trailing
         }
 
-        let sortedDates = chunks.sortedDates
-        if sortedDates.prefix(5).contains(chunk.date) {
+        let firstDate = chunks.sortedDates.first!
+        let first5Days = DateInterval(start: firstDate, end: firstDate.addingTimeInterval(4 * 24 * 3600))
+        if first5Days.contains(chunk.date) {
             position = .top
         }
 


### PR DESCRIPTION
- Check for the first 5 **charted** dates (first date in data set + 5 days), instead of calculating the first 5 days of the data set
- Closes #97 