### PR TITLE
Update rest settings to count completed focus blocks

### DIFF
--- a/Hourglass/Hourglass/Utilities/Constants.swift
+++ b/Hourglass/Hourglass/Utilities/Constants.swift
@@ -19,8 +19,8 @@ enum Constants {
     static let timerRestLarge = 20
 
     // Timer threshold defaults
-    static let restWarningThreshold: Int = 30
-    static let enforceRestThreshold: Int = -1
+    static let restWarningThreshold: Int = 1
+    static let enforceRestThreshold: Int = 2
     static let getBackToWorkIsEnabled: Bool = false
 
     // Timer alert dialog

--- a/Hourglass/Hourglass/Views/AlertView.swift
+++ b/Hourglass/Hourglass/Views/AlertView.swift
@@ -34,6 +34,6 @@ private extension AlertView {
         static let timerCompleteAlert = Constants.timerCompleteAlert
         static let timerResetAlert = "Timer has been reset."
         static let restWarningAlert = Constants.restWarningAlert
-        static let enforceRestAlert = "You've been focused for a while now. Let your mind rest."
+        static let enforceRestAlert = "You've been focused for a while now. Take a rest."
     }
 }

--- a/Hourglass/Hourglass/Views/RestSettingsFlow.swift
+++ b/Hourglass/Hourglass/Views/RestSettingsFlow.swift
@@ -21,12 +21,11 @@ struct RestSettingsFlow: View {
             Form {
                 Picker("Rest Reminder:", selection: $restWarningThreshold) {
                     Text("Off").tag(-1)
-                    Text("15 minutes").tag(15)
-                    Text("20 minutes").tag(20)
-                    Text("30 minutes").tag(30)
-                    Text("40 minutes").tag(40)
-                    Text("50 minutes").tag(50)
-                    Text("60 minutes").tag(60)
+                    Text("1 focus block").tag(1)
+                    Text("2 focus blocks").tag(2)
+                    Text("3 focus blocks").tag(3)
+                    Text("4 focus blocks").tag(4)
+                    Text("5 focus blocks").tag(5)
                 }
                 .onChange(of: restWarningThreshold) { _ in
                     if !dataIsValid { enforceRestThreshold = -1 }
@@ -35,12 +34,12 @@ struct RestSettingsFlow: View {
 
                 Picker("Enforce Rest:", selection: $enforceRestThreshold) {
                     Text("Off").tag(-1)
-                    Text("15 minutes").tag(15)
-                    Text("20 minutes").tag(20)
-                    Text("30 minutes").tag(30)
-                    Text("40 minutes").tag(40)
-                    Text("50 minutes").tag(50)
-                    Text("60 minutes").tag(60)
+                    Text("1 focus block").tag(1)
+                    Text("2 focus blocks").tag(2)
+                    Text("3 focus blocks").tag(3)
+                    Text("4 focus blocks").tag(4)
+                    Text("5 focus blocks").tag(5)
+                    Text("6 focus blocks").tag(6)
                 }
                 .onChange(of: enforceRestThreshold) { _ in
                     if !dataIsValid { restWarningThreshold = -1 }
@@ -82,8 +81,8 @@ struct RestSettingsFlow: View {
 
 private extension RestSettingsFlow {
     enum Copy {
-        static let restReminderHelp = "Reminds you to take a rest after (x) minutes of focus. Must be less than the enforce rest threshold."
-        static let enforceRestHelp = "Disables focus timers and forces you to take a rest. Triggered when ongoing timer is completed or cancelled. Must be greater than the rest reminder threshold."
+        static let restReminderHelp = "Reminds you to take a rest after completing (x) consecutive focus blocks. Must be less than the enforce rest threshold."
+        static let enforceRestHelp = "Disables focus timers, forcing you to take a rest after completing (x) consecutive focus blocks. Must be greater than the rest reminder threshold."
         static let getBackToWorkHelp = "Prohibits you from taking multiple rest blocks at a time."
         static let footnote = "Note: Hover to see settings descriptions."
     }

--- a/Hourglass/Hourglass/Views/SettingsMenu.swift
+++ b/Hourglass/Hourglass/Views/SettingsMenu.swift
@@ -108,13 +108,13 @@ struct SettingsMenu: View {
                     }
 
                     let restWarningThreshold = restWarningThreshold > 0 ? "\(restWarningThreshold)fb" : "Off"
-                    Text("Rest Reminder: \(restWarningThreshold)")
+                    DetailText("Rest Reminder: \(restWarningThreshold)")
 
                     let enforceRestThreshold = enforceRestThreshold > 0 ? "\(enforceRestThreshold)fb" : "Off"
-                    Text("Enforce Rest: \(enforceRestThreshold)")
+                    DetailText("Enforce Rest: \(enforceRestThreshold)")
 
                     let getBackToWorkIsEnabled = getBackToWorkIsEnabled ? "On" : "Off"
-                    Text("Get Back To Work: \(getBackToWorkIsEnabled)")
+                    DetailText("Get Back To Work: \(getBackToWorkIsEnabled)")
                 }
             }
             Section {
@@ -129,5 +129,18 @@ struct SettingsMenu: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("settings-button")
+    }
+}
+
+private struct DetailText: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 10))
     }
 }

--- a/Hourglass/Hourglass/Views/SettingsMenu.swift
+++ b/Hourglass/Hourglass/Views/SettingsMenu.swift
@@ -107,10 +107,10 @@ struct SettingsMenu: View {
                         viewModel.viewState.showRestSettingsFlow.toggle()
                     }
 
-                    let restWarningThreshold = restWarningThreshold > 0 ? "\(restWarningThreshold)m" : "Off"
+                    let restWarningThreshold = restWarningThreshold > 0 ? "\(restWarningThreshold)fb" : "Off"
                     Text("Rest Reminder: \(restWarningThreshold)")
 
-                    let enforceRestThreshold = enforceRestThreshold > 0 ? "\(enforceRestThreshold)m" : "Off"
+                    let enforceRestThreshold = enforceRestThreshold > 0 ? "\(enforceRestThreshold)fb" : "Off"
                     Text("Enforce Rest: \(enforceRestThreshold)")
 
                     let getBackToWorkIsEnabled = getBackToWorkIsEnabled ? "On" : "Off"

--- a/Hourglass/HourglassTests/ViewModelTests.swift
+++ b/Hourglass/HourglassTests/ViewModelTests.swift
@@ -152,44 +152,43 @@ final class ViewModelTests: XCTestCase {
     }
 
     func testRestWarning() {
-        let timerModel = timerModels[.focus]![0]
+        let timerModel3sFocus = timerModels[.focus]![0]
         settingsManager.setRestWarningThreshold(2)
 
-        viewModel.didTapTimer(from: timerModel)
-        (0..<2).forEach { _ in
+        viewModel.didTapTimer(from: timerModel3sFocus)
+        (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
+        assertUserNotification(.timerDidComplete, count: 1)
+        assertUserNotification(.restWarningThresholdMet, count: 0)
 
-        assertUserNotification(.timerDidComplete, count: 0)
+        viewModel.didTapTimer(from: timerModel3sFocus)
+        (0..<3).forEach { _ in
+            timerPublisher.send(now)
+        }
+        assertUserNotification(.timerDidComplete, count: 2)
         assertUserNotification(.restWarningThresholdMet, count: 1)
     }
 
     func testRestWarningResetAfterCompletedRestBlock() {
         let timerModel3sFocus = timerModels[.focus]![0]
         let timerModel5sRest = timerModels[.rest]![0]
-        settingsManager.setRestWarningThreshold(5)
+        settingsManager.setRestWarningThreshold(2)
 
-        // Complete 3s focus block
+        // Complete focus blocks
         viewModel.didTapTimer(from: timerModel3sFocus)
         (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
-
         assertUserNotification(.timerDidComplete, count: 1)
         assertUserNotification(.restWarningThresholdMet, count: 0)
 
-        // Start another 3s focus block
         viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<2).forEach { _ in
+        (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
-
-        // Verify rest warning is triggered
-        assertUserNotification(.timerDidComplete, count: 1)
-        assertUserNotification(.restWarningThresholdMet, count: 1)
-
-        timerPublisher.send(now)
         assertUserNotification(.timerDidComplete, count: 2)
+        assertUserNotification(.restWarningThresholdMet, count: 1)
 
         // Complete rest block
         viewModel.didTapTimer(from: timerModel5sRest)
@@ -199,40 +198,31 @@ final class ViewModelTests: XCTestCase {
         assertUserNotification(.timerDidComplete, count: 3)
 
         // Run focus blocks and verify that rest warning is triggered again
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<3).forEach { _ in
-            timerPublisher.send(now)
-        }
-        assertUserNotification(.timerDidComplete, count: 4)
-
-        viewModel.didTapTimer(from: timerModel3sFocus)
         (0..<2).forEach { _ in
-            timerPublisher.send(now)
+            viewModel.didTapTimer(from: timerModel3sFocus)
+            (0..<3).forEach { _ in
+                timerPublisher.send(now)
+            }
         }
-        assertUserNotification(.timerDidComplete, count: 4)
+        assertUserNotification(.timerDidComplete, count: 5)
         assertUserNotification(.restWarningThresholdMet, count: 2)
     }
 
     func testRestWarningDoesNotResetAfterIncompleteRestBlock() {
         let timerModel3sFocus = timerModels[.focus]![0]
         let timerModel5sRest = timerModels[.rest]![0]
-        settingsManager.setRestWarningThreshold(2)
+        settingsManager.setRestWarningThreshold(1)
 
-        // Run focus block
+        // Complete focus block
         viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<2).forEach { _ in
+        (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
-
         // Verify rest warning is triggered
-        assertUserNotification(.timerDidComplete, count: 0)
-        assertUserNotification(.restWarningThresholdMet, count: 1)
-
-        timerPublisher.send(now)
         assertUserNotification(.timerDidComplete, count: 1)
         assertUserNotification(.restWarningThresholdMet, count: 1)
 
-        // Cancel rest block
+        // Start and cancel rest block
         viewModel.didTapTimer(from: timerModel5sRest)
         timerPublisher.send(now)
         viewModel.didTapTimer(from: timerModel5sRest)
@@ -249,72 +239,22 @@ final class ViewModelTests: XCTestCase {
         assertUserNotification(.restWarningThresholdMet, count: 1)
     }
 
-    func testRestWarningContinuesAfterCancelledFocusBlock() {
-        let timerModel3sFocus = timerModels[.focus]![0]
-        settingsManager.setRestWarningThreshold(5)
-
-        // Start and cancel 3s focus block
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<2).forEach { _ in
-            timerPublisher.send(now)
-        }
-        viewModel.didTapTimer(from: timerModel3sFocus)
-
-        assertUserNotification(.timerDidComplete, count: 0)
-        assertUserNotification(.restWarningThresholdMet, count: 0)
-
-        // Start 3s focus block again
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<3).forEach { _ in
-            timerPublisher.send(now)
-        }
-
-        // Verify rest warning is triggered
-        assertUserNotification(.timerDidComplete, count: 1)
-        assertUserNotification(.restWarningThresholdMet, count: 1)
-    }
-
-    func testEnforceRestOnTimerComplete() {
-        let timerModel3sFocus = timerModels[.focus]![0]
-        settingsManager.setEnforceRestThreshold(5)
-
-        // Complete 3s focus block
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<3).forEach { _ in
-            timerPublisher.send(now)
-        }
-        assertUserNotification(.timerDidComplete, count: 1)
-        assertUserNotification(.enforceRestThresholdMet, count: 0)
-
-        // Start another 3s focus block
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<2).forEach { _ in
-            timerPublisher.send(now)
-        }
-        assertUserNotification(.timerDidComplete, count: 1)
-        assertUserNotification(.enforceRestThresholdMet, count: 0)
-
-        // Verify enforce rest is triggered when timer is complete
-        timerPublisher.send(now)
-        assertUserNotification(.timerDidComplete, count: 2)
-        assertUserNotification(.enforceRestThresholdMet, count: 1)
-        assertTimer(timerModel3sFocus, state: .disabled)
-    }
-
-    func testEnforceRestOnTimerCancel() {
+    func testEnforceRest() {
         let timerModel3sFocus = timerModels[.focus]![0]
         settingsManager.setEnforceRestThreshold(2)
 
-        // Run focus block
         viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<2).forEach { _ in
+        (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
+        assertUserNotification(.timerDidComplete, count: 1)
+        assertUserNotification(.enforceRestThresholdMet, count: 0)
 
-        // Cancel focus block
         viewModel.didTapTimer(from: timerModel3sFocus)
-
-        assertUserNotification(.timerDidComplete, count: 0)
+        (0..<3).forEach { _ in
+            timerPublisher.send(now)
+        }
+        assertUserNotification(.timerDidComplete, count: 2)
         assertUserNotification(.enforceRestThresholdMet, count: 1)
         assertTimer(timerModel3sFocus, state: .disabled)
     }
@@ -322,19 +262,21 @@ final class ViewModelTests: XCTestCase {
     func testEnforceRestResetAfterCompletedRestBlock() {
         let timerModel3sFocus = timerModels[.focus]![0]
         let timerModel5sRest = timerModels[.rest]![0]
-        settingsManager.setEnforceRestThreshold(5)
+        settingsManager.setEnforceRestThreshold(2)
 
-        // Complete 2 focus blocks
+        // Complete focus blocks
         viewModel.didTapTimer(from: timerModel3sFocus)
         (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
+        assertUserNotification(.timerDidComplete, count: 1)
+        assertUserNotification(.enforceRestThresholdMet, count: 0)
+
         viewModel.didTapTimer(from: timerModel3sFocus)
         (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
-
-        // Verify enforce rest is triggered when timer is complete
+        // Verify enforce rest is triggered
         assertUserNotification(.timerDidComplete, count: 2)
         assertUserNotification(.enforceRestThresholdMet, count: 1)
         assertTimer(timerModel3sFocus, state: .disabled)
@@ -344,22 +286,17 @@ final class ViewModelTests: XCTestCase {
         (0..<5).forEach { _ in
             timerPublisher.send(now)
         }
-
         // Verify that enforce rest is de-triggered
         assertUserNotification(.timerDidComplete, count: 3)
-        assertUserNotification(.enforceRestThresholdMet, count: 1)
         assertTimer(timerModel3sFocus, state: .inactive)
 
-        // Complete 2 focus blocks again
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<3).forEach { _ in
-            timerPublisher.send(now)
+        // Complete focus blocks and verify that enforce rest is triggered again
+        (0..<2).forEach { _  in
+            viewModel.didTapTimer(from: timerModel3sFocus)
+            (0..<3).forEach { _ in
+                timerPublisher.send(now)
+            }
         }
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<3).forEach { _ in
-            timerPublisher.send(now)
-        }
-
         // Verify that enforce rest is triggered again
         assertUserNotification(.timerDidComplete, count: 5)
         assertUserNotification(.enforceRestThresholdMet, count: 2)
@@ -369,62 +306,24 @@ final class ViewModelTests: XCTestCase {
     func testEnforceRestDoesNotResetAfterIncompleteRestBlock() {
         let timerModel3sFocus = timerModels[.focus]![0]
         let timerModel5sRest = timerModels[.rest]![0]
-        settingsManager.setEnforceRestThreshold(5)
-
-        // Complete 2 focus blocks
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<3).forEach { _ in
-            timerPublisher.send(now)
-        }
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<3).forEach { _ in
-            timerPublisher.send(now)
-        }
-
-        // Verify enforce rest is triggered when timer is complete
-        assertUserNotification(.timerDidComplete, count: 2)
-        assertUserNotification(.enforceRestThresholdMet, count: 1)
-        assertTimer(timerModel3sFocus, state: .disabled)
-
-        // Start and cancel rest block
-        viewModel.didTapTimer(from: timerModel5sRest)
-        (0..<4).forEach { _ in
-            timerPublisher.send(now)
-        }
-        viewModel.didTapTimer(from: timerModel5sRest)
-
-        // Verify that enforce rest is *still* triggered
-        assertUserNotification(.timerDidComplete, count: 2)
-        assertUserNotification(.enforceRestThresholdMet, count: 1)
-        assertTimer(timerModel3sFocus, state: .disabled)
-    }
-
-    func testEnforceRestContinuesAfterCancelledFocusBlock() {
-        let timerModel3sFocus = timerModels[.focus]![0]
-        settingsManager.setEnforceRestThreshold(5)
-
-        // Start and cancel focus block
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        timerPublisher.send(now)
-        viewModel.didTapTimer(from: timerModel3sFocus)
-
-        assertUserNotification(.timerDidComplete, count: 0)
-        assertUserNotification(.enforceRestThresholdMet, count: 0)
+        settingsManager.setEnforceRestThreshold(1)
 
         // Complete focus block
         viewModel.didTapTimer(from: timerModel3sFocus)
         (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
+        // Verify enforce rest is triggered
         assertUserNotification(.timerDidComplete, count: 1)
-        assertUserNotification(.enforceRestThresholdMet, count: 0)
+        assertUserNotification(.enforceRestThresholdMet, count: 1)
+        assertTimer(timerModel3sFocus, state: .disabled)
 
-        // Start and cancel focus block
-        viewModel.didTapTimer(from: timerModel3sFocus)
+        // Start and cancel rest block
+        viewModel.didTapTimer(from: timerModel5sRest)
         timerPublisher.send(now)
-        viewModel.didTapTimer(from: timerModel3sFocus)
+        viewModel.didTapTimer(from: timerModel5sRest)
 
-        // Verify enforce rest is triggered when timer is complete
+        // Verify that enforce rest is *still* triggered
         assertUserNotification(.timerDidComplete, count: 1)
         assertUserNotification(.enforceRestThresholdMet, count: 1)
         assertTimer(timerModel3sFocus, state: .disabled)
@@ -432,32 +331,33 @@ final class ViewModelTests: XCTestCase {
 
     func testRestWarningWithEnforceRestHappyPath() {
         let timerModel3sFocus = timerModels[.focus]![0]
-        settingsManager.setRestWarningThreshold(2)
-        settingsManager.setEnforceRestThreshold(5)
+        settingsManager.setRestWarningThreshold(1)
+        settingsManager.setEnforceRestThreshold(3)
 
-        // Run focus block
+        // Run focus blocks
         viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<2).forEach { _ in
+        (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
-        assertUserNotification(.timerDidComplete, count: 0)
-        assertUserNotification(.enforceRestThresholdMet, count: 0)
-        assertUserNotification(.restWarningThresholdMet, count: 1)
-        assertTimer(timerModel3sFocus, state: .active)
-
-        // Complete focus block
-        timerPublisher.send(now)
         assertUserNotification(.timerDidComplete, count: 1)
         assertUserNotification(.enforceRestThresholdMet, count: 0)
         assertUserNotification(.restWarningThresholdMet, count: 1)
         assertTimer(timerModel3sFocus, state: .inactive)
 
-        // Complete another focus block
         viewModel.didTapTimer(from: timerModel3sFocus)
         (0..<3).forEach { _ in
             timerPublisher.send(now)
         }
         assertUserNotification(.timerDidComplete, count: 2)
+        assertUserNotification(.enforceRestThresholdMet, count: 0)
+        assertUserNotification(.restWarningThresholdMet, count: 1)
+        assertTimer(timerModel3sFocus, state: .inactive)
+
+        viewModel.didTapTimer(from: timerModel3sFocus)
+        (0..<3).forEach { _ in
+            timerPublisher.send(now)
+        }
+        assertUserNotification(.timerDidComplete, count: 3)
         assertUserNotification(.enforceRestThresholdMet, count: 1)
         assertUserNotification(.restWarningThresholdMet, count: 1)
         assertTimer(timerModel3sFocus, state: .disabled)
@@ -465,8 +365,8 @@ final class ViewModelTests: XCTestCase {
 
     func testRestWarningAndEnforceRestOff() {
         let timerModel3sFocus = timerModels[.focus]![0]
-        settingsManager.setRestWarningThreshold(0)
-        settingsManager.setEnforceRestThreshold(0)
+        settingsManager.setRestWarningThreshold(-1)
+        settingsManager.setEnforceRestThreshold(-1)
 
         // Run focus block twice
         (0..<2).forEach { _ in
@@ -495,38 +395,22 @@ final class ViewModelTests: XCTestCase {
         (0..<5).forEach { _ in
             timerPublisher.send(now)
         }
-
-        // Verify rest timer disabled after completion
-        assertUserNotification(.timerDidComplete, count: 1)
         assertTimer(timerModel5sRest, state: .disabled)
-
-        // Run focus block
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<2).forEach { _ in
-            timerPublisher.send(now)
-        }
-
-        // Verify rest timer is still disabled while focus timer runs
-        assertUserNotification(.timerDidComplete, count: 1)
-        assertTimer(timerModel3sFocus, state: .active)
-        assertTimer(timerModel5sRest, state: .disabled)
+        assertTimer(timerModel3sFocus, state: .inactive)
 
         // Complete focus block
-        timerPublisher.send(now)
-
-        // Verify rest timer is enabled when focus timer completes
-        assertUserNotification(.timerDidComplete, count: 2)
+        viewModel.didTapTimer(from: timerModel3sFocus)
+        (0..<3).forEach { _ in
+            timerPublisher.send(now)
+        }
+        assertTimer(timerModel5sRest, state: .inactive)
         assertTimer(timerModel3sFocus, state: .inactive)
-        assertTimer(timerModel5sRest, state: .inactive)
     }
 
-    /**
-     Test that when getBackToWork is enabled, after completing a rest block, you cannot start another rest block until enforceRestThreshold is met (via cancelled focus blocks).
-     */
-    func testGetBackToWorkAndEnforceRestOnCancelledFocusBlock() {
+    func testGetBackToWorkAndEnforceRest() {
         let timerModel3sFocus = timerModels[.focus]![0]
         let timerModel5sRest = timerModels[.rest]![0]
-        settingsManager.setEnforceRestThreshold(3)
+        settingsManager.setEnforceRestThreshold(2)
         settingsManager.setGetBackToWork(isEnabled: true)
 
         // Complete rest block
@@ -535,49 +419,24 @@ final class ViewModelTests: XCTestCase {
             timerPublisher.send(now)
         }
         assertTimer(timerModel5sRest, state: .disabled)
-
-        // Run, cancel, and run focus block again
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        (0..<2).forEach { _ in
-            timerPublisher.send(now)
-        }
-        viewModel.didTapTimer(from: timerModel3sFocus)
-
-        viewModel.didTapTimer(from: timerModel3sFocus)
-        timerPublisher.send(now)
-        viewModel.didTapTimer(from: timerModel3sFocus)
-
-        assertUserNotification(.enforceRestThresholdMet, count: 1)
-        assertTimer(timerModel3sFocus, state: .disabled)
-        assertTimer(timerModel5sRest, state: .inactive)
-    }
-
-    /**
-     Test that when getBackToWork is enabled, after completing a rest block, you cannot start another rest block until enforceRestThreshold is met (via a completed focus block).
-     */
-    func testGetBackToWorkAndEnforceRestOnCompletedFocusBlock() {
-        let timerModel3sFocus = timerModels[.focus]![0]
-        let timerModel5sRest = timerModels[.rest]![0]
-        settingsManager.setEnforceRestThreshold(5)
-        settingsManager.setGetBackToWork(isEnabled: true)
-
-        // Complete rest block
-        viewModel.didTapTimer(from: timerModel5sRest)
-        (0..<5).forEach { _ in
-            timerPublisher.send(now)
-        }
-        assertTimer(timerModel5sRest, state: .disabled)
+        assertTimer(timerModel3sFocus, state: .inactive)
 
         // Complete focus blocks
-        (0..<2).forEach { _ in
-            viewModel.didTapTimer(from: timerModel3sFocus)
-            (0..<3).forEach { _ in
-                timerPublisher.send(now)
-            }
+        viewModel.didTapTimer(from: timerModel3sFocus)
+        (0..<3).forEach { _ in
+            timerPublisher.send(now)
         }
-        assertUserNotification(.enforceRestThresholdMet, count: 1)
-        assertTimer(timerModel3sFocus, state: .disabled)
         assertTimer(timerModel5sRest, state: .inactive)
+        assertTimer(timerModel3sFocus, state: .inactive)
+
+        viewModel.didTapTimer(from: timerModel3sFocus)
+        (0..<3).forEach { _ in
+            timerPublisher.send(now)
+        }
+        assertTimer(timerModel5sRest, state: .inactive)
+        assertTimer(timerModel3sFocus, state: .disabled)
+
+        assertUserNotification(.enforceRestThresholdMet, count: 1)
     }
 
     private func assertUserNotification(_ event: HourglassEventKey.Timer, count: Int) {


### PR DESCRIPTION
- Rest warning and enforce rest settings are now triggered by completing (x) consecutive focus blocks
- Simplify unit tests
- Closes #140 