### PR TITLE
Remove notification setting, default to Notification Center

### DIFF
--- a/Hourglass/Hourglass/Managers/SettingsManager.swift
+++ b/Hourglass/Hourglass/Managers/SettingsManager.swift
@@ -176,21 +176,4 @@ struct SettingsManager {
         as? Bool ?? Constants.fullscreenOnBreak
     }
      */
-
-    // Notification Style
-    func setNotification(style: NotificationStyle) {
-        store.set(style.rawValue, forKey: SettingsKeys.notificationStyle.rawValue)
-    }
-
-    func getNotificationStyle() -> NotificationStyle {
-        #if CITESTING
-        if let overrideValue = ProcessInfo.processInfo.environment[SettingsKeys.notificationStyle.rawValue] {
-            return NotificationStyle(rawValue: Int(overrideValue)!)!
-        }
-        #endif
-        let value = store.object(forKey: SettingsKeys.notificationStyle.rawValue)
-        as? Int ?? Constants.notificationStyle
-
-        return NotificationStyle(rawValue: value)!
-    }
 }

--- a/Hourglass/Hourglass/Managers/UserNotificationManager.swift
+++ b/Hourglass/Hourglass/Managers/UserNotificationManager.swift
@@ -2,7 +2,6 @@ import UserNotifications
 
 protocol NotificationManager {
     func fireNotification(_ notification: HourglassNotification, soundIsEnabled: Bool)
-    func fireNotificationSound(for: HourglassNotification)
 }
 
 class UserNotificationManager: NSObject, NotificationManager {
@@ -30,14 +29,6 @@ class UserNotificationManager: NSObject, NotificationManager {
         let notificationContent = notification.content
             .title(notification.title)
             .sound(soundIsEnabled ? notification.soundFX : nil)
-
-        fireNotification(id: notification.id, content: notificationContent)
-    }
-
-    func fireNotificationSound(for notification: HourglassNotification) {
-        let notificationContent = notification.content
-            .title("")
-            .sound(notification.soundFX)
 
         fireNotification(id: notification.id, content: notificationContent)
     }

--- a/Hourglass/Hourglass/Utilities/Constants.swift
+++ b/Hourglass/Hourglass/Utilities/Constants.swift
@@ -1,11 +1,8 @@
 import Foundation
 
 enum Constants {
-    // Notification style default
-    static let notificationStyle = NotificationStyle.popup.rawValue
-
     // Fullscreen-on-break default
-    static let fullscreenOnBreak = true
+    // static let fullscreenOnBreak = true
 
     // Sound default
     static let soundIsEnabled = true

--- a/Hourglass/Hourglass/Utilities/Notifications.swift
+++ b/Hourglass/Hourglass/Utilities/Notifications.swift
@@ -12,12 +12,7 @@ enum HourglassNotification: String {
     }
 
     var soundFX: UNNotificationSound? {
-        switch self {
-        case .restWarningThresholdMetNotif:
-            return nil
-        default:
-            return UNNotificationSound.default
-        }
+        return UNNotificationSound.default
     }
 
     var title: String {

--- a/Hourglass/Hourglass/ViewModel.swift
+++ b/Hourglass/Hourglass/ViewModel.swift
@@ -121,7 +121,7 @@ extension ViewModel: EventNotifying {
     @objc func notifyUser(timerEvent: HourglassEventKey.Timer) {
         switch timerEvent {
         case .timerDidComplete:
-            notifyUser(.timerCompleteNotif, alertFlag: &viewState.showTimerCompleteAlert)
+            notifyUser(.timerCompleteNotif)
         default:
             break
         }
@@ -130,7 +130,7 @@ extension ViewModel: EventNotifying {
     @objc func notifyUser(progressEvent: HourglassEventKey.Progress) {
         switch progressEvent {
         case .restWarningThresholdMet:
-            notifyUser(.restWarningThresholdMetNotif, alertFlag: &viewState.showRestWarningAlert)
+            notifyUser(.restWarningThresholdMetNotif)
         case .enforceRestThresholdMet:
             viewState.showEnforceRestAlert.toggle()
             windowCoordinator?.showPopoverIfNeeded()
@@ -140,28 +140,15 @@ extension ViewModel: EventNotifying {
         }
     }
 
-    private func notifyUser(_ notification: HourglassNotification, alertFlag: inout Bool) {
-        let soundIsEnabled = settingsManager.getSoundIsEnabled()
-
-        switch settingsManager.getNotificationStyle() {
-        case .banner:
-            userNotificationManager.fireNotification(notification, soundIsEnabled: soundIsEnabled)
-        case .popup:
-            if soundIsEnabled {
-                userNotificationManager.fireNotificationSound(for: notification)
-            }
-            alertFlag.toggle()
-            windowCoordinator?.showPopoverIfNeeded()
-        }
+    private func notifyUser(_ notification: HourglassNotification) {
+        userNotificationManager.fireNotification(notification, soundIsEnabled: settingsManager.getSoundIsEnabled())
     }
 }
 
 extension ViewModel {
     struct ViewState {
         var showStartNewTimerDialog: Bool = false
-        var showTimerCompleteAlert: Bool = false
         var showTimerResetAlert: Bool = false
-        var showRestWarningAlert: Bool = false
         var showEnforceRestAlert: Bool = false
         var showRestSettingsFlow: Bool = false
         var showGetBackToWorkAlert: Bool = false

--- a/Hourglass/Hourglass/Views/AlertView.swift
+++ b/Hourglass/Hourglass/Views/AlertView.swift
@@ -19,8 +19,6 @@ struct AlertView: View {
             .alert(Copy.getBackToWorkAlert, isPresented: $viewModel.viewState.showGetBackToWorkAlert) {}
             .alert(Copy.timerResetAlert, isPresented: $viewModel.viewState.showTimerResetAlert) {}
             .alert(Copy.enforceRestAlert, isPresented: $viewModel.viewState.showEnforceRestAlert) {}
-            .alert(Copy.restWarningAlert, isPresented: $viewModel.viewState.showRestWarningAlert) {}
-            .alert(Copy.timerCompleteAlert, isPresented: $viewModel.viewState.showTimerCompleteAlert) {}
             .sheet(isPresented: $viewModel.viewState.showRestSettingsFlow) {
                 RestSettingsFlow(viewModel: viewModel, settingsManager: settingsManager)
             }
@@ -32,9 +30,7 @@ private extension AlertView {
         static let startNewTimerDialogPrompt = "Are you sure you want to start a new timer?"
         static let startNewTimerDialogConfirm = "Start timer"
         static let startNewTimerDialogCancel = "Cancel"
-        static let timerCompleteAlert = Constants.timerCompleteAlert
         static let timerResetAlert = "Timer has been reset."
-        static let restWarningAlert = Constants.restWarningAlert
         static let enforceRestAlert = "You've been focused for a while now. Take a rest."
         static let getBackToWorkAlert = "Get back to work!"
     }

--- a/Hourglass/Hourglass/Views/SettingsMenu.swift
+++ b/Hourglass/Hourglass/Views/SettingsMenu.swift
@@ -10,9 +10,6 @@ struct SettingsMenu: View {
      - The UserDefaults cache gets written to only when selecting new options via the Menu.
      */
 
-    @AppStorage(SettingsKeys.notificationStyle.rawValue)
-    var notificationStyle: NotificationStyle = .init(rawValue: Constants.notificationStyle)!
-
     @AppStorage(SettingsKeys.soundIsEnabled.rawValue)
     var soundIsEnabled: Bool = Constants.soundIsEnabled
 
@@ -55,14 +52,6 @@ struct SettingsMenu: View {
                     viewModel.showStatisticsWindow()
                 }
                 Section("Options") {
-                    Picker("Notification Style", selection: $notificationStyle) {
-                        Text("Menu Bar Popup").tag(NotificationStyle.popup)
-                        Text("Notification Banner").tag(NotificationStyle.banner)
-                    }
-                    .onChange(of: notificationStyle) { newValue in
-                        viewModel.logEvent(.notificationStyleSet(newValue))
-                    }
-
                     Toggle("Sound", isOn: $soundIsEnabled)
                     // TODO: - Implement fullscreen on rest (#14)
                     // Toggle("Fullscreen on Rest", isOn: .constant(true))

--- a/Hourglass/HourglassUITests/HourglassUITests.swift
+++ b/Hourglass/HourglassUITests/HourglassUITests.swift
@@ -44,26 +44,6 @@ final class HourglassUITests: XCTestCase {
         XCTAssertTrue(settingsButton.exists)
     }
 
-    func testStartTimerToCompletionPopup() {
-        app.setNotificationStyle(.popup)
-        app.launchMenu()
-
-        // Tap 3s timer
-        let (_, timerGridButtons) = timerGrid
-        timerGridButtons[3].tap()
-
-        let alert = app.sheets.matching(identifier: "alert").element
-        XCTAssertTrue(alert.waitForExistence(timeout: 4))
-
-        let alertTitle = alert.staticTexts["Time is up."]
-        let okButton = alert.buttons["OK"]
-        [alertTitle, okButton].forEach { element in
-            XCTAssertTrue(element.exists)
-        }
-
-        okButton.tap()
-    }
-
     /**
      Test local notification via UNUserNotificationCenter on timer complete.
 
@@ -74,7 +54,6 @@ final class HourglassUITests: XCTestCase {
      - Menu bar is not hidden (Desktop and Dock system settings)
      */
     func DISABLED_testStartTimerToCompletionBanner() {
-        app.setNotificationStyle(.banner)
         app.launchMenu()
 
         // Tap 3s timer
@@ -189,12 +168,5 @@ extension XCUIApplication {
 
     func log() {
         print(debugDescription)
-    }
-}
-
-// Settings override helpers via launch environment
-extension XCUIApplication {
-    func setNotificationStyle(_ style: NotificationStyle) {
-        launchEnvironment[SettingsKeys.notificationStyle.rawValue] = String(style.rawValue)
     }
 }


### PR DESCRIPTION
- Default to notification center (banner) notifications
  - Timer complete
  - Rest warning
- Show alerts when UI is affected
  - Enforce rest which disables focus timers
  - Get back to work which disables rest timers
- Possible combinations
  - Timer complete banner
  - Timer complete banner + rest soon banner
  - Timer complete banner + enforce rest alert
  - GBTW alert
- Closes #141 